### PR TITLE
Integration with convex-fraxusdc

### DIFF
--- a/contracts/protocols/convex/fraxusdc/Allocation.sol
+++ b/contracts/protocols/convex/fraxusdc/Allocation.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.6.11;
+pragma experimental ABIEncoderV2;
+
+import {IERC20} from "contracts/common/Imports.sol";
+import {SafeMath} from "contracts/libraries/Imports.sol";
+import {ImmutableAssetAllocation} from "contracts/tvl/Imports.sol";
+
+import {ConvexFraxUsdcConstants} from "./Constants.sol";
+
+import {
+    ConvexAllocationBase
+} from "contracts/protocols/convex/common/Imports.sol";
+import {
+    Curve3poolUnderlyerConstants
+} from "contracts/protocols/curve/3pool/Constants.sol";
+
+contract ConvexFraxUsdcAllocation is
+    ConvexAllocationBase,
+    ImmutableAssetAllocation,
+    ConvexFraxUsdcConstants,
+    Curve3poolUnderlyerConstants
+{
+    function balanceOf(address account, uint8 tokenIndex)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        return
+            super.getUnderlyerBalance(
+                account,
+                STABLE_SWAP_ADDRESS,
+                REWARD_CONTRACT_ADDRESS,
+                LP_TOKEN_ADDRESS,
+                uint256(tokenIndex)
+            );
+    }
+
+    function _getTokenData()
+        internal
+        pure
+        override
+        returns (TokenData[] memory)
+    {
+        TokenData[] memory tokens = new TokenData[](2);
+        tokens[0] = TokenData(FRAX_ADDRESS, "DAI", 18);
+        tokens[1] = TokenData(USDC_ADDRESS, "USDC", 6);
+        return tokens;
+    }
+}

--- a/contracts/protocols/convex/fraxusdc/Constants.sol
+++ b/contracts/protocols/convex/fraxusdc/Constants.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.6.11;
+
+import {INameIdentifier} from "contracts/common/Imports.sol";
+
+abstract contract ConvexFraxUsdcConstants is INameIdentifier {
+    string public constant override NAME = "convex-fraxusdc";
+
+    uint256 public constant PID = 100;
+
+    address public constant STABLE_SWAP_ADDRESS =
+        0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2;
+    address public constant LP_TOKEN_ADDRESS =
+        0x3175Df0976dFA876431C2E9eE6Bc45b65d3473CC;
+    address public constant REWARD_CONTRACT_ADDRESS =
+        0x7e880867363A7e321f5d260Cade2B0Bb2F717B02;
+
+    address public constant FRAX_ADDRESS =
+        0x853d955aCEf822Db058eb8505911ED77F175b99e;
+    /**
+     * @dev USDC gets imported by `Curve3poolUnderlyerConstants`
+     * in zap and allocation contracts
+     */
+    //address public constant USDC_ADDRESS =
+    //0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+}

--- a/contracts/protocols/convex/fraxusdc/Zap.sol
+++ b/contracts/protocols/convex/fraxusdc/Zap.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.6.11;
+pragma experimental ABIEncoderV2;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {
+    IStableSwap2 as IStableSwap,
+    ILiquidityGauge
+} from "contracts/protocols/curve/common/interfaces/Imports.sol";
+import {ConvexZapBase} from "../common/Imports.sol";
+import {ConvexFraxUsdcConstants} from "./Constants.sol";
+
+contract ConvexFraxUsdcZap is ConvexZapBase, ConvexFraxUsdcConstants {
+    constructor()
+        public
+        ConvexZapBase(STABLE_SWAP_ADDRESS, LP_TOKEN_ADDRESS, PID, 10000, 100, 2)
+    {} // solhint-disable no-empty-blocks
+
+    function assetAllocations() public view override returns (string[] memory) {
+        string[] memory allocationNames = new string[](1);
+        allocationNames[1] = NAME;
+        return allocationNames;
+    }
+
+    function erc20Allocations() public view override returns (IERC20[] memory) {
+        IERC20[] memory allocations = new IERC20[](3);
+        allocations[0] = IERC20(CRV_ADDRESS);
+        allocations[1] = IERC20(FRAX_ADDRESS);
+        allocations[2] = IERC20(USDC_ADDRESS);
+        return allocations;
+    }
+
+    function _addLiquidity(uint256[] calldata amounts, uint256 minAmount)
+        internal
+        override
+    {
+        IStableSwap(SWAP_ADDRESS).add_liquidity(
+            [amounts[0], amounts[1]],
+            minAmount
+        );
+    }
+
+    function _removeLiquidity(
+        uint256 lpBalance,
+        uint8 index,
+        uint256 minAmount
+    ) internal override {
+        require(index < 2, "INVALID_INDEX");
+        require(index > 0, "CANT_WITHDRAW_PRIMARY");
+        IStableSwap(SWAP_ADDRESS).remove_liquidity_one_coin(
+            lpBalance,
+            index,
+            minAmount
+        );
+    }
+
+    function _getVirtualPrice() internal view override returns (uint256) {
+        return IStableSwap(SWAP_ADDRESS).get_virtual_price();
+    }
+
+    function _getCoinAtIndex(uint256 i)
+        internal
+        view
+        override
+        returns (address)
+    {
+        return IStableSwap(SWAP_ADDRESS).coins(i);
+    }
+}

--- a/contracts/protocols/convex/fraxusdc/Zap.sol
+++ b/contracts/protocols/convex/fraxusdc/Zap.sol
@@ -18,7 +18,7 @@ contract ConvexFraxUsdcZap is ConvexZapBase, ConvexFraxUsdcConstants {
 
     function assetAllocations() public view override returns (string[] memory) {
         string[] memory allocationNames = new string[](1);
-        allocationNames[1] = NAME;
+        allocationNames[0] = NAME;
         return allocationNames;
     }
 

--- a/test-integration/ConvexAllocations.js
+++ b/test-integration/ConvexAllocations.js
@@ -205,7 +205,7 @@ async function getContractAt(
   return contract;
 }
 
-describe.only("Convex Allocations", () => {
+describe("Convex Allocations", () => {
   /* signers */
   let deployer;
   let emergencySafe;

--- a/test-integration/ConvexAllocations.js
+++ b/test-integration/ConvexAllocations.js
@@ -17,7 +17,7 @@ const { WHALE_POOLS } = require("../utils/constants");
 console.debugging = false;
 /* ************************ */
 
-const pinnedBlock = 13818110;
+const pinnedBlock = 15085764;
 const defaultPinnedBlock = hre.config.networks.hardhat.forking.blockNumber;
 const forkingUrl = hre.config.networks.hardhat.forking.url;
 
@@ -93,6 +93,21 @@ const ConvexPoolAllocations = [
       IStableSwap: "IOldStableSwap3",
     },
     unwrap: true,
+  },
+  {
+    contractName: "ConvexFraxUsdcAllocation",
+    poolName: "FraxUsdc",
+    pid: 100,
+    // using the Curve pool itself as the "whale":
+    // should be ok since the pool's external balances (vs the pool's
+    // internal balances) are only used for admin balances and determining
+    // deposit amounts for "fee" assets.
+    whaleAddress: "0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2",
+    numberOfCoins: 2,
+    interfaceOverride: {
+      IStableSwap: "IStableSwap2",
+    },
+    unwrap: false,
   },
 ];
 
@@ -190,7 +205,7 @@ async function getContractAt(
   return contract;
 }
 
-describe("Convex Allocations", () => {
+describe.only("Convex Allocations", () => {
   /* signers */
   let deployer;
   let emergencySafe;

--- a/test-integration/ConvexZaps.js
+++ b/test-integration/ConvexZaps.js
@@ -22,7 +22,7 @@ const CVX_ADDRESS = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
 console.debugging = false;
 /* ************************ */
 
-const pinnedBlock = 13616400;
+const pinnedBlock = 15085764;
 const defaultPinnedBlock = hre.config.networks.hardhat.forking.blockNumber;
 const forkingUrl = hre.config.networks.hardhat.forking.url;
 
@@ -111,6 +111,16 @@ describe("Convex Zaps - LP Account integration", () => {
       numberOfCoins: 3,
       whaleAddress: WHALE_POOLS["DAI"],
       useUnwrapped: true,
+    },
+    {
+      contractName: "ConvexFraxUsdcZap",
+      swapAddress: "0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2",
+      swapInterface: "IStableSwap2",
+      lpTokenAddress: "0x3175Df0976dFA876431C2E9eE6Bc45b65d3473CC",
+      rewardContractAddress: "0x7e880867363A7e321f5d260Cade2B0Bb2F717B02",
+      rewardContractInterface: "IBaseRewardPool",
+      numberOfCoins: 2,
+      whaleAddress: WHALE_POOLS["FRAX"],
     },
   ];
 


### PR DESCRIPTION
A debatable design decision was to only create the asset allocation for the Convex position and not create one for the Curve position. The original Curve asset allocations were there for positions that were not Convex-boosted, and were left in as requirements for the Convex zaps as a defensive measure in case liquidity was ever stuck in an in-between state.

The question is if it is still necessary to do this. The downside to doing it is the duplicate code and duplicate hardcoded addresses.